### PR TITLE
speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: setup ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: install dependencies
-        run: |
-          sudo gem install jekyll bundler
-          bundle install
+      - name: setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+          bundler-cache: true
       - name: build site
         run: |
           bundle exec jekyll build

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 3.8.5"
+gem "jekyll", "~> 4.2.0"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.2.0"
+gem "jekyll", "~> 3.8.5"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ cover_image: ""
 # Force include of files from documentation 
 exclude:
   - /docs/
+  - vendor
 
 ############################################################
 # Site configuration for the Jekyll 3 Pagination Gem


### PR DESCRIPTION
This PR:
- uses official [setup-ruby](https://github.com/ruby/setup-ruby) action with bundler cache enabled.
- fixes jekyll build (ref: https://jekyllrb.com/docs/troubleshooting/#configuration-problems)
- brings down the setup+build+deploy (wait) time from ~4m40s to <30s.