### PR TITLE
Add link to Rizin website

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,7 @@
             <div class="col-md-6">
             <div class="banner-content">
                 <h1 class="big-font1 white-text m-b-50" style="display: inline">{{ site.title }}</h1>
-                <h5 class="white-text m-b-50">Free and Open Source RE Platform powered by Rizin
+                <h5 class="white-text m-b-50">Free and Open Source RE Platform powered by <a href="https://rizin.re">Rizin</a>
                 </h5>
                 <ul class="banner-btn m-0 list-inline">
                     <li class="list-inline-item"><a href="#" id="downloadBtn" class="dwn-btn1 btn btn-primary"><span>Download</span></a></li>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -14,5 +14,6 @@
         <li><a href="/#features" class="js-scroll-trigger">Features</a></li>
         <li><a href="/docs/" class="js-scroll-trigger">Documentation</a></li>
         <li><a href="/#community" class="js-scroll-trigger">Community</a></li>
+        <li><a href="https://rizin.re" class="js-scroll-trigger">Rizin</a></li>
     </ul>
 </nav>

--- a/pages/about.md
+++ b/pages/about.md
@@ -3,7 +3,7 @@ layout: page-md
 title: About Cutter
 permalink: /about/
 ---
-<p><strong>Cutter</strong> is a Qt and C++ GUI powered by Rizin. Its goal is making an advanced, customizable and FOSS reverse-engineering platform while keeping the user experience at mind. Cutter is created by reverse engineers for reverse engineers.</p>
+<p><strong>Cutter</strong> is a Qt and C++ GUI powered by [Rizin](https://rizin.re). Its goal is making an advanced, customizable and FOSS reverse-engineering platform while keeping the user experience at mind. Cutter is created by reverse engineers for reverse engineers.</p>
 <p>Cutter is actively maintained by its developer team and releases a new feature every ~5 weeks. Naturally, Cutter enjoys the fast paced development of its core, Rizin. This makes the project one of the most actively developed RE frameworks.</p>
 
 ![Cutter's Screenshot](/assets/images/cutter-screenshot.png)

--- a/pages/getting-started.md
+++ b/pages/getting-started.md
@@ -3,7 +3,7 @@ layout: page-md
 title: Getting Started
 permalink: /getting-started/
 ---
-Cutter is a Qt and C++ GUI powered by Rizin. Its goal is making an advanced, customizable and FOSS reverse-engineering platform while keeping the user experience at mind. Cutter is created by reverse engineers for reverse engineers.
+Cutter is a Qt and C++ GUI powered by [Rizin](https://rizin.re). Its goal is making an advanced, customizable and FOSS reverse-engineering platform while keeping the user experience at mind. Cutter is created by reverse engineers for reverse engineers.
 
 Cutter is actively maintained by its developer team and releases a new feature every ~5 weeks. Naturally, Cutter enjoys the fast paced development of its core, Rizin. This makes the project one of the most actively developed RE frameworks.
 


### PR DESCRIPTION
Rizin has links to Cutter, but Cutter isn't. Fix that.

Closes https://github.com/rizinorg/cutter.re/issues/46